### PR TITLE
fix #3【4系】eye_catchの復元に失敗したときにWarning (2)になる問題を解決

### DIFF
--- a/Event/RevisionControlViewEventListener.php
+++ b/Event/RevisionControlViewEventListener.php
@@ -50,10 +50,12 @@ class RevisionControlViewEventListener extends BcViewEventListener {
 									Configure::read('RevisionControl.actsAs.BcUpload.' . $overWriteModel)) {
 									$fileFields = Configure::read('RevisionControl.actsAs.BcUpload.' . $overWriteModel);
 									foreach($fileFields as $fileField) {
+										if (empty($dataObj[$modelName][$fileField])) {
+											continue;
+										}
 										$fieldData = $dataObj[$modelName][$fileField];
 										$revId = $data['RevisionControl']['id'];
-										if (empty($fieldData)) {
-										} else {
+										if (!empty($fieldData)) {
 											$path = "$bkDir/$revId/$fieldData";
 											$view->request->data[$overWriteModel][$fileField] = $path;
 										}


### PR DESCRIPTION
こちら、どなたにプルリク送ったら良いのかわからないのですが、
プルリク送っておきます。